### PR TITLE
Add deployments configs

### DIFF
--- a/confident/confident.py
+++ b/confident/confident.py
@@ -1,12 +1,13 @@
+import importlib
+import inspect
 import os
 from copy import deepcopy
 from typing import Union, List, Any, Dict, Optional
 
-from confident.utils import load_config_file, load_env_files
+from confident.utils import load_file, load_env_files
 from config_property import ConfigProperty
 from config_source import ConfigSource
 from pydantic import BaseModel
-from pydantic.fields import ModelField
 
 SPECS_ATTR = '_specs'
 FULL_CONFIG_ATTR = '_full'
@@ -22,6 +23,11 @@ class ConfidentConfigSpecs(BaseModel):
     prefer_files: bool = False
     ignore_missing_files: bool = True
     explicit_fields: Optional[Dict['str', Any]] = None
+    deployment_name: Optional[str] = None
+    deployment_attr: Optional[str] = None
+    deployments: Optional[Union[Dict[str, Union[Dict[str, str], str]], str]] = None
+    class_path: Optional[str] = None
+    creation_path: Optional[str] = None
 
 
 class Confident(BaseModel):
@@ -41,7 +47,10 @@ class Confident(BaseModel):
             config_files: Optional[Union[str, List[str]]] = None,
             prefer_files: bool = False,
             ignore_missing_files: bool = True,
-            fields: Optional[Dict['str', Any]] = None
+            fields: Optional[Dict['str', Any]] = None,
+            deployment_name: Optional[str] = None,
+            deployment_attr: Optional[str] = None,
+            deployments: Optional[Union[Dict[str, Union[Dict[str, str], str]], str]] = None
     ):
         """
         Args:
@@ -56,30 +65,42 @@ class Confident(BaseModel):
             fields: Dictionary of keys matching the object fields names to override their values.
         """
         # Prepare metadata.
+        subclass_location = self.get_subclass_file_path()
+        caller_module = inspect.getmodule(inspect.stack()[1][0])
+        caller_location = caller_module.__file__ if caller_module else None
+
         if specs_path:
             specs = ConfidentConfigSpecs.parse_file(specs_path)
             specs.specs_path = specs_path
         else:
             env_files = [env_files] if isinstance(env_files, str) else env_files or []
             config_files = [config_files] if isinstance(config_files, str) else config_files or []
-            specs = ConfidentConfigSpecs(specs_path=specs_path, env_files=env_files, config_files=config_files,
-                                         prefer_file=prefer_files, ignore_missing_files=ignore_missing_files,
-                                         explicit_fields=fields)
+            specs = ConfidentConfigSpecs(
+                specs_path=specs_path, env_files=env_files, config_files=config_files,
+                prefer_file=prefer_files, ignore_missing_files=ignore_missing_files,
+                explicit_fields=fields, deployment_name=deployment_name, deployment_attr=deployment_attr,
+                deployments=deployments, class_path=subclass_location, creation_path=caller_location
+            )
 
         # Load properties from all sources.
         if specs.env_files:
             load_env_files(specs.env_files)
-        env_properties = self._load_env_properties()
-        file_properties = self._load_file_properties(specs)
-        explicit_properties = self._load_explicit_properties(specs)
-        default_properties = self._load_default_properties()
+        env_vars_properties = self._load_env_properties()
+        file_properties = self._load_file_properties(specs=specs)
+        explicit_properties = self._load_explicit_properties(specs=specs)
+        default_properties = self._load_default_properties(specs=specs)
 
         full_properties = self._merge_properties(
             specs=specs,
             explicit_properties=explicit_properties,
-            env_properties=env_properties,
+            env_vars_properties=env_vars_properties,
             file_properties=file_properties,
             default_properties=default_properties
+        )
+
+        deployment_properties = self._load_deployment_properties(specs=specs, properties=full_properties)
+        full_properties = self._merge_env_default_properties(
+            properties=full_properties, deployment_properties=deployment_properties
         )
 
         # Create the final object.
@@ -91,14 +112,14 @@ class Confident(BaseModel):
 
     @staticmethod
     def _merge_properties(
-            specs, explicit_properties, env_properties, file_properties, default_properties
+            specs, explicit_properties, env_vars_properties, file_properties, default_properties
     ) -> Dict[str, Any]:
         """
         Construct a dictionary with properties from all sources according to their priority.
         Args:
             specs: Config specifications object.
             explicit_properties: Fields that were given explicitly in the constructor.
-            env_properties: Fields retrieved from environment variables.
+            env_vars_properties: Fields retrieved from environment variables.
             file_properties: Fields retrieved from files.
             default_properties: Default values in the class declaration.
 
@@ -107,12 +128,70 @@ class Confident(BaseModel):
         """
         properties = {}
         if specs.prefer_files:
-            properties.update({**default_properties, **explicit_properties, **env_properties, **file_properties})
+            properties.update({**default_properties, **explicit_properties, **env_vars_properties, **file_properties})
         else:
-            properties.update({**default_properties, **explicit_properties, **file_properties, **env_properties})
+            properties.update({**default_properties, **explicit_properties, **file_properties, **env_vars_properties})
         return properties
 
-    def _load_default_properties(self) -> Dict[str, Any]:
+    @staticmethod
+    def _merge_env_default_properties(
+            properties: Dict[str, ConfigProperty], deployment_properties: Dict[str, Any]
+    ):
+        for name, config_property in deployment_properties.items():
+            if properties[name].source_type == ConfigSource.class_default:
+                properties[name] = config_property
+        return properties
+
+    @staticmethod
+    def _load_deployment_properties(specs: ConfidentConfigSpecs, properties: Dict[str, ConfigProperty]):
+        """
+        Loads the relevant deployment config properties.
+
+        Args:
+            specs: Config specifications object.
+            properties: All loaded properties to find the deployment attribute in.
+        """
+        deployment_name = specs.deployment_name
+        deployment_attr = specs.deployment_attr
+        deployments = specs.deployments
+        deployment_location = specs.creation_path
+
+        if deployment_attr is None and deployment_name is None:
+            return {}
+        if deployment_attr is not None and deployment_name is not None:
+            raise ValueError('Can not have both `deployment_attr` and `deployment_name`. Only one can be used.')
+        if deployments is None:
+            raise ValueError('Environment default is enabled but no `deployments` was provided.')
+        if isinstance(deployments, str):
+            deployment_location = deployments
+            deployments = load_file(deployment_location)
+
+        deployment = {}
+        deployment_properties = {}
+
+        if deployment_name:
+            deployment = deployments.get(deployment_name)
+        if deployment_attr:
+            deployment_name = properties.get(deployment_attr).value
+            if not isinstance(deployment_name, str):
+                raise ValueError(f'deployment_attr: {deployment_attr} is not valid.')
+            deployment = deployments.get(deployment_name)
+
+        if isinstance(deployment, str):
+            deployment = load_file(deployment)
+
+        for name, value in deployment.items():
+            deployment_properties[name] = ConfigProperty(
+                name=name,
+                value=value,
+                source_name=deployment_name,
+                source_type=ConfigSource.deployment,
+                source_location=deployment_location,
+            )
+
+        return deployment_properties
+
+    def _load_default_properties(self, specs: ConfidentConfigSpecs) -> Dict[str, ConfigProperty]:
         """
         Loads default values declared in the inheriting class into a dictionary.
         """
@@ -124,19 +203,24 @@ class Confident(BaseModel):
                 default_properties[field_name] = ConfigProperty(
                     name=field_name,
                     value=default_value,
-                    source_name=ConfigSource.class_default,
-                    source_type=ConfigSource.class_default
+                    source_name=self.__class__.__name__,
+                    source_type=ConfigSource.class_default,
+                    source_location=specs.class_path,
                 )
         return default_properties
 
     @staticmethod
-    def _load_explicit_properties(specs: ConfidentConfigSpecs) -> Dict[str, Any]:
+    def _load_explicit_properties(specs: ConfidentConfigSpecs) -> Dict[str, ConfigProperty]:
         if not specs.explicit_fields:
             return {}
-        return {key: ConfigProperty(name=key, value=value, source_name=ConfigSource.explicit,
-                                    source_type=ConfigSource.explicit) for key, value in specs.explicit_fields.items()}
+        return {
+            key: ConfigProperty(
+                name=key, value=value, source_name=ConfigSource.explicit, source_type=ConfigSource.explicit,
+                source_location=specs.creation_path
+            ) for key, value in specs.explicit_fields.items()
+        }
 
-    def _load_env_properties(self) -> Dict[str, Any]:
+    def _load_env_properties(self) -> Dict[str, ConfigProperty]:
         """
         Finds and loads requested config fields from environment variables into a dictionary.
         """
@@ -145,11 +229,12 @@ class Confident(BaseModel):
         for key in self.__fields__.keys():
             env_value = os.getenv(key)
             if env_value:
-                env_properties[key] = ConfigProperty(name=key, value=env_value, source_name=ConfigSource.environment,
-                                                     source_type=ConfigSource.environment)
+                env_properties[key] = ConfigProperty(
+                    name=key, value=env_value, source_name=key, source_type=ConfigSource.env_var, source_location=key
+                )
         return env_properties
 
-    def _load_file_properties(self, specs: ConfidentConfigSpecs) -> Dict[str, Any]:
+    def _load_file_properties(self, specs: ConfidentConfigSpecs) -> Dict[str, ConfigProperty]:
         """
         Finds and loads requested config fields from files into a dictionary.
 
@@ -160,12 +245,21 @@ class Confident(BaseModel):
         for file_path in specs.config_files:
             if not os.path.isfile(file_path) and specs.ignore_missing_files:
                 continue
-            file_dict = load_config_file(path=file_path)
+            file_dict = load_file(path=file_path)
+
             file_properties.update(
-                {key: ConfigProperty(name=key, value=value, source_name=file_path,
-                                     source_type=ConfigSource.file) for key, value in file_dict.items()})
+                {key: ConfigProperty(
+                    name=key, value=value, source_name=os.path.basename(file_path),
+                    source_type=ConfigSource.file, source_location=file_path
+                ) for key, value in file_dict.items()})
 
         return {key: file_properties[key] for key in file_properties.keys() & self.__fields__.keys()}
+
+    def get_subclass_file_path(self):
+        try:
+            return importlib.import_module(self.__module__).__file__
+        except ImportError:
+            return self.__module__
 
     def get_specs(self):
         return deepcopy(self.__getattribute__(SPECS_ATTR))

--- a/confident/config_property.py
+++ b/confident/config_property.py
@@ -13,6 +13,7 @@ class ConfigProperty(BaseModel):
     value_type: type
     source_name: str
     source_type: ConfigSource
+    source_location: str
 
     def __init__(self, value: Any, **kwargs):
         value_type = type(value)

--- a/confident/config_source.py
+++ b/confident/config_source.py
@@ -5,7 +5,8 @@ class ConfigSource(str, Enum):
     """
     Possible kinds of configuration sources.
     """
-    environment = 'environment'
+    env_var = 'env_var'
     file = 'file'
     explicit = 'explicit'
     class_default = 'class_default'
+    deployment = 'deployment'

--- a/confident/utils.py
+++ b/confident/utils.py
@@ -6,7 +6,7 @@ import yaml
 from dotenv import load_dotenv
 
 
-def load_config_file(path: str) -> Dict[str, Any]:
+def load_file(path: str) -> Dict[str, Any]:
     """
     Loads fields from a file into a dictionary.
 


### PR DESCRIPTION
Add the option to insert properties that will be selected according to a chosen deployment name.

For every different deployment name there will be a different set of properties that will be loaded into the confident object.
Add config_location attribute to ConfigProperty to recognize where the value of the property came from.