### PR TITLE
Add tests for defining specs with `ConfidentConfig` class in the mode…

### DIFF
--- a/confident/confident.py
+++ b/confident/confident.py
@@ -130,7 +130,7 @@ class Confident(BaseModel):
                 specs_path=specs_path,
                 env_files=env_files,
                 files=files,
-                prefer_file=prefer_files,
+                prefer_files=prefer_files,
                 ignore_missing_files=ignore_missing_files,
                 explicit_fields=fields,
                 deployment_name=deployment_name or class_config_dict.get(CONFIG_CLASS_DEPLOYMENT_NAME_ATTR),
@@ -285,6 +285,7 @@ class Confident(BaseModel):
                 If the `deployment_name` is not of type `str`.
                 If the `deployment_field` appears inside the `deployment_config`.
         """
+        # Extracts the deployment metadata field and validates them.
         deployment_name = specs.deployment_name
         deployment_field = specs.deployment_field
         deployment_config = specs.deployment_config
@@ -295,7 +296,7 @@ class Confident(BaseModel):
         if deployment_field is not None and deployment_name is not None:
             raise ValueError('Cannot have both `deployment_field` and `deployment_name`. Only one can be used.')
         if deployment_config is None:
-            raise ValueError('Environment default is enabled but no `deployment_config` was provided.')
+            raise ValueError('No `deployment_config` was provided.')
         if isinstance(deployment_config, Path):
             deployment_location = deployment_config
             deployment_config = load_file(deployment_location)
@@ -303,6 +304,7 @@ class Confident(BaseModel):
         deployment = {}
         deployment_properties = {}
 
+        # According to the deployment name, extracts the chosen deployment.
         if deployment_name:
             deployment = deployment_config.get(deployment_name)
         if deployment_field:
@@ -322,9 +324,13 @@ class Confident(BaseModel):
                 )
             deployment = deployment_config.get(deployment_name)
 
+        if deployment is None:
+            raise KeyError(f'No matching deployment to {deployment_name=}. Check your `deployment_config`')
+
         if isinstance(deployment, str):
             deployment = load_file(deployment)
 
+        # Creates the `ConfigProperty` dictionary.
         for name, value in deployment.items():
             if name == deployment_field:
                 raise ValueError(

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
       name='confident',
-      version='0.1.5',
+      version='0.1.6',
       description='Loading configurations from multiple sources into a data model.',
       long_description=open('README.md').read(),
       long_description_content_type='text/markdown',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ SAMPLE_1_ENV_FILE_NAME = 'temp_conf1.env'
 # Spec files:
 SPECS_1_FILE_NAME = 'temp_specs1.json'
 # Deployment config files:
-DEPLOYMENT_CONFIG_SAMPLE_1_FILE_NAME = "temp_deployment_config.json"
+DEPLOYMENT_CONFIG_SAMPLE_1_FILE_NAME = 'temp_deployment_config.json'
 
 # Test field names:
 SAMPLE_1_FIELD_1 = 'title'

--- a/tests/test_config_class.py
+++ b/tests/test_config_class.py
@@ -1,0 +1,78 @@
+from confident import Confident
+from confident.config_source import ConfigSource
+from tests.conftest import DEPLOYMENT_CONFIG_SAMPLE_1_FILE_NAME, DEPLOY_CONFIG_SAMPLE_1_FIELD_1
+
+
+def test__config_class_loading__files():
+    """
+    Checks if file specs properties are inserted correctly from a `ConfidentConfig` class declaration.
+    Doesn't check the logic - this is done in `test_confident.py`.
+    """
+    # Arrange:
+    class MyConfig(Confident):
+        property_a: str = 'nothing'
+
+        class ConfidentConfig:
+            env_files = 'temp.env'
+            files = 'temp.json'
+            prefer_files = True
+            ignore_missing_files = True
+            source_priority = [ConfigSource.explicit]
+
+    # Act
+    config = MyConfig()
+
+    # Assert
+    specs = config.specs()
+    # `env_files` and `files` are inserted into a list as Path objects.
+    assert str(specs.env_files.pop()) == 'temp.env'
+    assert str(specs.files.pop()) == 'temp.json'
+    assert specs.prefer_files is True
+    assert specs.ignore_missing_files is True
+    assert specs.source_priority == [ConfigSource.explicit]
+
+
+def test__config_class_loading__deployment_name(json_deployment_config_file_path_4_5):
+    """
+    Checks if file specs properties are inserted correctly from a `ConfidentConfig` class declaration.
+    Doesn't check the logic - this is done in `test_confident.py`.
+    """
+    # Arrange:
+    class MyConfig(Confident):
+        property_a: str = 'nothing'
+
+        class ConfidentConfig:
+            deployment_config = 'temp_deployment_config.json'
+            deployment_name = 'prod'
+
+    # Act
+    config = MyConfig()
+
+    # Assert
+    specs = config.specs()
+    # Also check that the values matches the test input from conftest.py.
+    assert str(specs.deployment_config) == 'temp_deployment_config.json' == DEPLOYMENT_CONFIG_SAMPLE_1_FILE_NAME
+    assert specs.deployment_name == 'prod' == DEPLOY_CONFIG_SAMPLE_1_FIELD_1
+
+
+def test__config_class_loading__deployment_field(json_deployment_config_file_path_4_5):
+    """
+    Checks if file specs properties are inserted correctly from a `ConfidentConfig` class declaration.
+    Doesn't check the logic - this is done in `test_confident.py`.
+    """
+    # Arrange:
+    class MyConfig(Confident):
+        property_a: str = 'prod'
+
+        class ConfidentConfig:
+            deployment_config = 'temp_deployment_config.json'
+            deployment_field = 'property_a'
+
+    # Act
+    config = MyConfig()
+
+    # Assert
+    specs = config.specs()
+    # Also check that the values matches the test input from conftest.py.
+    assert str(specs.deployment_config) == 'temp_deployment_config.json' == DEPLOYMENT_CONFIG_SAMPLE_1_FILE_NAME
+    assert specs.deployment_field == 'property_a'


### PR DESCRIPTION
…ls declaration.

Add indicative error when the deployment_name key is not exists in the deployment config.
Fix 'prefer_files' name in `ConfidentConfigSpecs` creation.